### PR TITLE
Add CI for building release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: release
+on:
+    push:
+        tags:
+            - '*'
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v2
+            - name: Set up Go
+              uses: actions/setup-go@v2
+              with:
+                  go-version: "1.16.6"
+            - name: Get the version
+              uses: olegtarasov/get-tag@v2.1
+              id: tagName
+            - name: Build the binary
+              run: |
+                  make geth
+            - name: Create Release
+              id: create_release
+              uses: softprops/action-gh-release@v1
+              with:
+                  files: |
+                      ./build/bin/geth

--- a/consensus/clique/ren.go
+++ b/consensus/clique/ren.go
@@ -144,7 +144,7 @@ func (d *DNR) Watch(ctx context.Context, db ethdb.Database) {
 
 		lastBlock = lastBlockNumber.Uint64()
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(time.Second * 30)
 	}
 }
 

--- a/consensus/clique/ren.go
+++ b/consensus/clique/ren.go
@@ -144,7 +144,7 @@ func (d *DNR) Watch(ctx context.Context, db ethdb.Database) {
 
 		lastBlock = lastBlockNumber.Uint64()
 
-		time.Sleep(time.Second * 30)
+		time.Sleep(5 * time.Second)
 	}
 }
 


### PR DESCRIPTION
- Add a CI to automatically build and publish the binary when new tags been pushed 